### PR TITLE
command-line/parser: command line parser and nop parser generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 bin/
+src/parser/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,27 @@ set(CMAKE_C_COMPILER clang)
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 
-include_directories(${LLVM_INCLUDE_DIRS}
-		${PROJECT_SRC_DIR}/src)
+include_directories(
+		${LLVM_INCLUDE_DIRS}
+		${PROJECT_SRC_DIR}/src
+		${PROJECT_SOURCE_DIR}/src/CommandParse
+		${PROJECT_SOURCE_DIR}/src/parser
+		/usr/local/include/antlr4-runtime
+		/usr/include/antlr4-runtime
+)
 
 add_definitions(${LLVM_DEFINITIONS})
 
-add_executable(nopc src/main.cpp)
+add_executable(nopc
+		src/main.cpp
+		src/CommandParse/CommandParse.cpp
+		src/parser/nopListener.cpp
+		src/parser/nopLexer.cpp
+		src/parser/nopBaseListener.cpp
+		src/parser/nopParser.cpp
+		)
 
 llvm_map_components_to_libnames(llvm_libs support core irreader)
 
 target_link_libraries(nopc ${llvm_libs})
+target_link_libraries(nopc antlr4-runtime)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # Compiler for nop
 Please refer to the contribution guidelines [here](CONTRIBUTING.md)
+
+## Installation :
+
+
+### Prerequisites :
+
+You have to install antlr4 first:
+- With your package manager <br>
+  Make sure that `antlr4` works and has Cpp compatibility
+
+- By Downloading latest complete version at https://www.antlr.org/download/index.html <br>
+and moving the .jar file at /usr/local/bin/antlr4.jar
+
+You have to install antlr4-runtime library:
+- Download latest C++ runtime lib at https://www.antlr.org/download/index.html and extract it<br>
+  To compile it :
+  ```
+  $ mkdir build && mkdir run && cd build
+  $ cmake .. -DANTLR_JAR_LOCATION=full/path/to/antlr4-VERSION-complete.jar -DWITH_DEMO=True
+  $ make
+  $ DESTDIR=../runtime/Cpp/run make install
+  ```
+  You then have to move the created files to your local files :
+  ```
+  $ cd ../runtime/Cpp/run/
+  $ cp usr/local/lib/* /usr/local/lib/
+  $ cp -r usr/local/include/antlr4-runtime/ /usr/local/include/
+  $ cp -r usr/local/share /usr/local/share/
+  ```
+
+### Building the nopc-bootstrap:
+
+```./build.sh```
+
+The binary of nopc is located at **./bin/nopc**

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+if [[ -x "$(command -v antlr4)" ]]; then
+	antlr4 -Dlanguage=Cpp nop.g4 -o ./src/parser/
+elif [[ -f /usr/local/bin/antlr4.jar ]]; then
+	java -jar /usr/local/bin/antlr4.jar -Dlanguage=Cpp nop.g4 -o ./src/parser/
+else
+	echo "You must install antlr4, see README.md"
+	exit 1
+fi
+
 declare build_dir="build"
 
 if [[ ! -d "${build_dir}" ]]; then

--- a/src/CommandParse/CommandParse.cpp
+++ b/src/CommandParse/CommandParse.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+#include "CommandParse.hpp"
+
+bool DebugFlag;
+bool VerboseFlag;
+
+CommandParse::CommandParse() :
+    InputFiles(llvm::cl::Positional, llvm::cl::desc("<input files>"), llvm::cl::OneOrMore),
+    OutputFilename("o", llvm::cl::desc("Specify output filename"), llvm::cl::value_desc("filename"), llvm::cl::Required),
+    Debug("d", llvm::cl::desc("Activate debug mode"), llvm::cl::location(DebugFlag)),
+    DebugLong("debug", llvm::cl::desc("Activate debug mode"), llvm::cl::aliasopt(Debug)),
+    Verbose("v", llvm::cl::desc("Activate verbose mode"), llvm::cl::location(VerboseFlag))
+{
+}
+
+CommandParse::~CommandParse() = default;
+
+void CommandParse::parse(int argc, char **argv)
+{
+    llvm::cl::ParseCommandLineOptions(argc, argv);
+}
+
+
+llvm::cl::list<std::string> &CommandParse::getInputFiles()
+{
+    return InputFiles;
+}
+
+std::string CommandParse::getOutputFile() const
+{
+    return OutputFilename;
+}

--- a/src/CommandParse/CommandParse.hpp
+++ b/src/CommandParse/CommandParse.hpp
@@ -1,0 +1,29 @@
+#ifndef NOPC_COMMANDPARSE_HPP
+#define NOPC_COMMANDPARSE_HPP
+
+#include <llvm/Support/CommandLine.h>
+#include "DebugFlag.hpp"
+
+// TODO: temporary, add more argument parsing stuff using llvm's CommandLine.h here
+//       docs: https://llvm.org/docs/CommandLine.html
+
+class CommandParse
+{
+public:
+    CommandParse();
+    ~CommandParse();
+    void parse(int argc, char **argv);
+
+    llvm::cl::list<std::string> &getInputFiles();
+    std::string getOutputFile() const;
+
+private:
+    llvm::cl::list<std::string> InputFiles;
+    llvm::cl::opt<std::string> OutputFilename;
+    llvm::cl::opt<bool, true> Debug;
+    llvm::cl::alias DebugLong;
+    llvm::cl::opt<bool, true> Verbose;
+};
+
+
+#endif //NOPC_COMMANDPARSE_HPP

--- a/src/CommandParse/DebugFlag.hpp
+++ b/src/CommandParse/DebugFlag.hpp
@@ -1,0 +1,23 @@
+#ifndef NOPC_DEBUGFLAG_HPP
+#define NOPC_DEBUGFLAG_HPP
+
+extern bool DebugFlag;
+extern bool VerboseFlag;
+
+#define IFDEBUG(X) if (DebugFlag) { X; }
+#define IFVERBOSE(X) if (VerboseFlag) {X; }
+
+// TODO: Create a logger for both Debug and Verbose
+
+#define LOG_DEBUG(msg) IFDEBUG( \
+    std::cerr << "\033[31;1;1m  DEBUG\033[0m " << __FILE__ << ":" << __LINE__ << "\t" << msg << std::endl; \
+)
+
+#define LOG_VERBOSE(msg) IFVERBOSE( \
+    std::cerr << "\033[33;1;1mVERBOSE\033[0m " << __FILE__ << ":" << __LINE__ << "\t" << msg << std::endl; \
+)
+
+#define LOG_ERROR(msg) \
+    std::cerr << "\033[31;1;1m  ERROR " << __FILE__ << ":" << __LINE__ << "\t" << msg << "\033[0m" << std::endl; \
+
+#endif //NOPC_DEBUGFLAG_HPP

--- a/src/ParsingTools.hpp
+++ b/src/ParsingTools.hpp
@@ -1,0 +1,25 @@
+/*
+** EPITECH PROJECT, 2019
+** nopc-bootstrap
+** File description:
+** ParsingTools.hpp
+*/
+
+#ifndef NOPC_BOOTSTRAP_PARSINGTOOLS_HPP
+#define NOPC_BOOTSTRAP_PARSINGTOOLS_HPP
+
+class ParserErrorListener: public antlr4::BaseErrorListener {
+    virtual void syntaxError(
+        antlr4::Recognizer *recognizer,
+        antlr4::Token *offendingSymbol,
+        size_t line,
+        size_t charPositionInLine,
+        const std::string &msg,
+        std::exception_ptr e) override {
+        std::ostringstream s;
+        s << "Line(" << line << ":" << charPositionInLine << ") Error(" << msg << ")";
+        throw std::invalid_argument(s.str());
+    }
+};
+
+#endif //NOPC_BOOTSTRAP_PARSINGTOOLS_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,51 @@
 #include <iostream>
-#include <llvm/Support/CommandLine.h>
+#include "CommandParse.hpp"
+#include "nopLexer.h"
+#include "nopParser.h"
+#include "ParsingTools.hpp"
 
-using namespace llvm;
+int parse_files(CommandParse &commandParse)
+{
+    ParserErrorListener errorListener;
 
-int main(int argc, char **argv) {
-	cl::ParseCommandLineOptions(argc, argv);
+    for (auto &InputFile : commandParse.getInputFiles()) {
+        LOG_VERBOSE("Parsing " << InputFile)
+        try {
+            std::ifstream stream(InputFile);
+            antlr4::ANTLRInputStream input(stream);
 
-	// TODO: temporary, add argument parsing stuff using llvm's CommandLine.h here
-	//       docs: https://llvm.org/docs/CommandLine.html
-	std::cout << "hello, world!" << std::endl;
-	return 0;
+            nopLexer lexer(&input);
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(&errorListener);
+
+            antlr4::CommonTokenStream tokens(&lexer);
+            tokens.fill();
+
+            nopParser parser(&tokens);
+            parser.removeErrorListeners();
+            parser.addErrorListener(&errorListener);
+            antlr4::tree::ParseTree *tree = parser.nop_file();
+
+            LOG_DEBUG(tree->toStringTree(&parser));
+        } catch (std::invalid_argument &e) {
+            LOG_ERROR(e.what());
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    CommandParse commandParse;
+
+    commandParse.parse(argc, argv);
+    IFDEBUG(
+        LOG_DEBUG("Output : " << commandParse.getOutputFile());
+        LOG_DEBUG("Inputs :");
+        for (auto &InputFile : commandParse.getInputFiles()) {
+            LOG_DEBUG("\t" << InputFile);
+        }
+    )
+    return parse_files(commandParse);
 }


### PR DESCRIPTION
Basic tooling for recover options in command line using LLVM's CommandLine library.
Also provide primitive macros for Debug & Verbose modes and logging from both.

Get :
&nbsp;&nbsp; - Input files (no option)
&nbsp;&nbsp;    - Output file
&nbsp;&nbsp;    - Debug mode
&nbsp;&nbsp;    - Verbose mode


Added per request build of antlr parser in `build.sh` file.
Instructions to install antlr4 are added in `README.md`