### PR TITLE
build: Force CMake everytime and suppress warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,12 @@ set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 
 include_directories(
-		${LLVM_INCLUDE_DIRS}
+		SYSTEM ${LLVM_INCLUDE_DIRS}
 		${PROJECT_SRC_DIR}/src
 		${PROJECT_SOURCE_DIR}/src/CommandParse
-		${PROJECT_SOURCE_DIR}/src/parser
-		/usr/local/include/antlr4-runtime
-		/usr/include/antlr4-runtime
+		SYSTEM ${PROJECT_SOURCE_DIR}/src/parser
+		SYSTEM /usr/local/include/antlr4-runtime
+		SYSTEM /usr/include/antlr4-runtime
 )
 
 add_definitions(${LLVM_DEFINITIONS})

--- a/build.sh
+++ b/build.sh
@@ -11,8 +11,10 @@ fi
 
 declare build_dir="build"
 
-if [[ ! -d "${build_dir}" ]]; then
-	cmake -Bbuild -H. -GNinja
+if ! cmake -Bbuild -H. -GNinja; then
+	echo "An error has occurred while generating ninja build file."
+	echo "Please resolve it and rerun this script."
+	exit 1
 fi
 
 ninja -C "${build_dir}"


### PR DESCRIPTION
CMake is now ran every time and build.sh will properly error out if there was an error.
Warnings have been suppressed by including the libraries as system headers (which are given leniency as per this: https://gcc.gnu.org/onlinedocs/cpp/System-Headers.html).