### PR TITLE
compiler: Error on missing file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,9 @@ int parse_files(CommandParse &commandParse)
         LOG_VERBOSE("Parsing " << InputFile)
         try {
             std::ifstream stream(InputFile);
+	    if (!stream.good()) {
+                throw std::invalid_argument("Invalid file " + InputFile);
+	    }
             antlr4::ANTLRInputStream input(stream);
 
             nopLexer lexer(&input);


### PR DESCRIPTION
Check for missing file while compiling to ensure <EOF> errors doesn't come out of nowhere.
This code gives up when a non-existent file is provided.