### PR TITLE
formatting: Apply clang-format

### DIFF
--- a/src/ASTParser/AST.hpp
+++ b/src/ASTParser/AST.hpp
@@ -4,14 +4,13 @@
 #include <string>
 
 class OperationAST {
-public:
-    ~OperationAST() = default;
+    public:
+	~OperationAST() = default;
 };
 class StatementAST : public OperationAST {};
 class LiteralAST : public StatementAST {};
 
 /*******/
-
 
 /*
  * Functions for AST
@@ -19,26 +18,29 @@ class LiteralAST : public StatementAST {};
 // TODO: Change type to look more like in .g4 file
 
 class FunctionParameterAST {
-public:
-private:
-    std::vector<std::string> Identifiers;
-    std::string type;
+    public:
+    private:
+	std::vector<std::string> Identifiers;
+	std::string type;
 };
 
 class FunctionHeaderAST {
-public:
-    FunctionHeaderAST(std::string identifier, std::string returnType)
-    : Identifier(std::move(identifier)), ReturnType(std::move(returnType)) {}
-private:
-    std::string Identifier;
-    std::string ReturnType;
+    public:
+	FunctionHeaderAST(std::string identifier, std::string returnType)
+		: Identifier(std::move(identifier)),
+		  ReturnType(std::move(returnType)) {
+	}
+
+    private:
+	std::string Identifier;
+	std::string ReturnType;
 };
 
 class FunctionAST {
-public:
-private:
-    FunctionHeaderAST FunctionHeader;
-    std::vector<OperationAST> Operations;
+    public:
+    private:
+	FunctionHeaderAST FunctionHeader;
+	std::vector<OperationAST> Operations;
 };
 
 /*
@@ -46,30 +48,39 @@ private:
  */
 
 class LetVariableDefinitionAST {
-public:
-    LetVariableDefinitionAST(bool Pub, bool Mut, bool Static, std::string Identifier)
-    : Pub(Pub), Mut(Mut), Static(Static), Identifier(std::move(Identifier)) {}
-private:
-    bool Pub;
-    bool Mut;
-    bool Static;
-    std::string Identifier;
+    public:
+	LetVariableDefinitionAST(bool Pub, bool Mut, bool Static,
+				 std::string Identifier)
+		: Pub(Pub), Mut(Mut), Static(Static),
+		  Identifier(std::move(Identifier)) {
+	}
+
+    private:
+	bool Pub;
+	bool Mut;
+	bool Static;
+	std::string Identifier;
 };
 
 class LetAST : public OperationAST {
-public:
-    LetAST(std::vector<LetVariableDefinitionAST> Vars, StatementAST Value)
-    : Vars(std::move(Vars)), Value(Value) {}
-private:
-    std::vector<LetVariableDefinitionAST> Vars;
-    StatementAST Value;
+    public:
+	LetAST(std::vector<LetVariableDefinitionAST> Vars, StatementAST Value)
+		: Vars(std::move(Vars)), Value(Value) {
+	}
+
+    private:
+	std::vector<LetVariableDefinitionAST> Vars;
+	StatementAST Value;
 };
 
 class ReturnStatementAST : public OperationAST {
-public:
-    explicit ReturnStatementAST(StatementAST Statement) : Statement(Statement) {}
-private:
-    StatementAST Statement;
+    public:
+	explicit ReturnStatementAST(StatementAST Statement)
+		: Statement(Statement) {
+	}
+
+    private:
+	StatementAST Statement;
 };
 
 /*
@@ -77,44 +88,55 @@ private:
  */
 
 class FunctionCallAST : public StatementAST {
-public:
-    FunctionCallAST(std::string Called, std::vector<std::unique_ptr<StatementAST>> Args)
-    : Called(std::move(Called)), Args(std::move(Args)) {}
-private:
-    std::string Called;
-    std::vector<std::unique_ptr<StatementAST>> Args;
+    public:
+	FunctionCallAST(std::string Called,
+			std::vector<std::unique_ptr<StatementAST> > Args)
+		: Called(std::move(Called)), Args(std::move(Args)) {
+	}
+
+    private:
+	std::string Called;
+	std::vector<std::unique_ptr<StatementAST> > Args;
 };
 
 /*
  * Literals for AST
  */
 
-class StringAST: public LiteralAST {
-public:
-    explicit StringAST(std::string Str) : Str(std::move(Str)) {}
-private:
-    std::string Str;
+class StringAST : public LiteralAST {
+    public:
+	explicit StringAST(std::string Str) : Str(std::move(Str)) {
+	}
+
+    private:
+	std::string Str;
 };
 
-class NumberAST: public LiteralAST {
-public:
-    explicit NumberAST(std::string Nbr) : Nbr(std::move(Nbr)) {}
-private:
-    std::string Nbr;
+class NumberAST : public LiteralAST {
+    public:
+	explicit NumberAST(std::string Nbr) : Nbr(std::move(Nbr)) {
+	}
+
+    private:
+	std::string Nbr;
 };
 
-class FloatAST: public LiteralAST {
-public:
-    explicit FloatAST(std::string Float) : Float(std::move(Float)) {}
-private:
-    std::string Float;
+class FloatAST : public LiteralAST {
+    public:
+	explicit FloatAST(std::string Float) : Float(std::move(Float)) {
+	}
+
+    private:
+	std::string Float;
 };
 
-class BooleanAST: public LiteralAST {
-public:
-    explicit BooleanAST(bool Bool) : Bool(Bool) {}
-private:
-    bool Bool;
+class BooleanAST : public LiteralAST {
+    public:
+	explicit BooleanAST(bool Bool) : Bool(Bool) {
+	}
+
+    private:
+	bool Bool;
 };
 
 #endif //NOPC_BOOTSTRAP_AST_HPP

--- a/src/CommandParse/CommandParse.cpp
+++ b/src/CommandParse/CommandParse.cpp
@@ -4,29 +4,29 @@
 bool DebugFlag;
 bool VerboseFlag;
 
-CommandParse::CommandParse() :
-    InputFiles(llvm::cl::Positional, llvm::cl::desc("<input files>"), llvm::cl::OneOrMore),
-    OutputFilename("o", llvm::cl::desc("Specify output filename"), llvm::cl::value_desc("filename"), llvm::cl::Required),
-    Debug("d", llvm::cl::desc("Activate debug mode"), llvm::cl::location(DebugFlag)),
-    DebugLong("debug", llvm::cl::desc("Activate debug mode"), llvm::cl::aliasopt(Debug)),
-    Verbose("v", llvm::cl::desc("Activate verbose mode"), llvm::cl::location(VerboseFlag))
-{
+CommandParse::CommandParse()
+	: InputFiles(llvm::cl::Positional, llvm::cl::desc("<input files>"),
+		     llvm::cl::OneOrMore),
+	  OutputFilename("o", llvm::cl::desc("Specify output filename"),
+			 llvm::cl::value_desc("filename"), llvm::cl::Required),
+	  Debug("d", llvm::cl::desc("Activate debug mode"),
+		llvm::cl::location(DebugFlag)),
+	  DebugLong("debug", llvm::cl::desc("Activate debug mode"),
+		    llvm::cl::aliasopt(Debug)),
+	  Verbose("v", llvm::cl::desc("Activate verbose mode"),
+		  llvm::cl::location(VerboseFlag)) {
 }
 
 CommandParse::~CommandParse() = default;
 
-void CommandParse::parse(int argc, char **argv)
-{
-    llvm::cl::ParseCommandLineOptions(argc, argv);
+void CommandParse::parse(int argc, char **argv) {
+	llvm::cl::ParseCommandLineOptions(argc, argv);
 }
 
-
-llvm::cl::list<std::string> &CommandParse::getInputFiles()
-{
-    return InputFiles;
+llvm::cl::list<std::string> &CommandParse::getInputFiles() {
+	return InputFiles;
 }
 
-std::string CommandParse::getOutputFile() const
-{
-    return OutputFilename;
+std::string CommandParse::getOutputFile() const {
+	return OutputFilename;
 }

--- a/src/CommandParse/CommandParse.hpp
+++ b/src/CommandParse/CommandParse.hpp
@@ -7,23 +7,21 @@
 // TODO: temporary, add more argument parsing stuff using llvm's CommandLine.h here
 //       docs: https://llvm.org/docs/CommandLine.html
 
-class CommandParse
-{
-public:
-    CommandParse();
-    ~CommandParse();
-    void parse(int argc, char **argv);
+class CommandParse {
+    public:
+	CommandParse();
+	~CommandParse();
+	void parse(int argc, char **argv);
 
-    llvm::cl::list<std::string> &getInputFiles();
-    std::string getOutputFile() const;
+	llvm::cl::list<std::string> &getInputFiles();
+	std::string getOutputFile() const;
 
-private:
-    llvm::cl::list<std::string> InputFiles;
-    llvm::cl::opt<std::string> OutputFilename;
-    llvm::cl::opt<bool, true> Debug;
-    llvm::cl::alias DebugLong;
-    llvm::cl::opt<bool, true> Verbose;
+    private:
+	llvm::cl::list<std::string> InputFiles;
+	llvm::cl::opt<std::string> OutputFilename;
+	llvm::cl::opt<bool, true> Debug;
+	llvm::cl::alias DebugLong;
+	llvm::cl::opt<bool, true> Verbose;
 };
-
 
 #endif //NOPC_COMMANDPARSE_HPP

--- a/src/CommandParse/DebugFlag.hpp
+++ b/src/CommandParse/DebugFlag.hpp
@@ -4,20 +4,27 @@
 extern bool DebugFlag;
 extern bool VerboseFlag;
 
-#define IFDEBUG(X) if (DebugFlag) { X; }
-#define IFVERBOSE(X) if (VerboseFlag) {X; }
+#define IFDEBUG(X)                                                             \
+	if (DebugFlag) {                                                       \
+		X;                                                             \
+	}
+#define IFVERBOSE(X)                                                           \
+	if (VerboseFlag) {                                                     \
+		X;                                                             \
+	}
 
 // TODO: Create a logger for both Debug and Verbose
 
-#define LOG_DEBUG(msg) IFDEBUG( \
-    std::cerr << "\033[31;1;1m  DEBUG\033[0m " << __FILE__ << ":" << __LINE__ << "\t" << msg << std::endl; \
-)
+#define LOG_DEBUG(msg)                                                         \
+	IFDEBUG(std::cerr << "\033[31;1;1m  DEBUG\033[0m " << __FILE__ << ":"  \
+			  << __LINE__ << "\t" << msg << std::endl;)
 
-#define LOG_VERBOSE(msg) IFVERBOSE( \
-    std::cerr << "\033[33;1;1mVERBOSE\033[0m " << __FILE__ << ":" << __LINE__ << "\t" << msg << std::endl; \
-)
+#define LOG_VERBOSE(msg)                                                       \
+	IFVERBOSE(std::cerr << "\033[33;1;1mVERBOSE\033[0m " << __FILE__       \
+			    << ":" << __LINE__ << "\t" << msg << std::endl;)
 
-#define LOG_ERROR(msg) \
-    std::cerr << "\033[31;1;1m  ERROR " << __FILE__ << ":" << __LINE__ << "\t" << msg << "\033[0m" << std::endl; \
+#define LOG_ERROR(msg)                                                         \
+	std::cerr << "\033[31;1;1m  ERROR " << __FILE__ << ":" << __LINE__     \
+		  << "\t" << msg << "\033[0m" << std::endl;
 
 #endif //NOPC_DEBUGFLAG_HPP

--- a/src/ParsingTools.hpp
+++ b/src/ParsingTools.hpp
@@ -1,18 +1,17 @@
 #ifndef NOPC_BOOTSTRAP_PARSINGTOOLS_HPP
 #define NOPC_BOOTSTRAP_PARSINGTOOLS_HPP
 
-class ParserErrorListener: public antlr4::BaseErrorListener {
-    virtual void syntaxError(
-        antlr4::Recognizer *recognizer,
-        antlr4::Token *offendingSymbol,
-        size_t line,
-        size_t charPositionInLine,
-        const std::string &msg,
-        std::exception_ptr e) override {
-        std::ostringstream s;
-        s << "Line(" << line << ":" << charPositionInLine << ") Error(" << msg << ")";
-        throw std::invalid_argument(s.str());
-    }
+class ParserErrorListener : public antlr4::BaseErrorListener {
+	virtual void syntaxError(antlr4::Recognizer *recognizer,
+				 antlr4::Token *offendingSymbol, size_t line,
+				 size_t charPositionInLine,
+				 const std::string &msg,
+				 std::exception_ptr e) override {
+		std::ostringstream s;
+		s << "Line(" << line << ":" << charPositionInLine << ") Error("
+		  << msg << ")";
+		throw std::invalid_argument(s.str());
+	}
 };
 
 #endif //NOPC_BOOTSTRAP_PARSINGTOOLS_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,51 +4,48 @@
 #include "nopParser.h"
 #include "ParsingTools.hpp"
 
-int parse_files(CommandParse &commandParse)
-{
-    ParserErrorListener errorListener;
+int parse_files(CommandParse &commandParse) {
+	ParserErrorListener errorListener;
 
-    for (auto &InputFile : commandParse.getInputFiles()) {
-        LOG_VERBOSE("Parsing " << InputFile)
-        try {
-            std::ifstream stream(InputFile);
-	    if (!stream.good()) {
-                throw std::invalid_argument("Invalid file " + InputFile);
-	    }
-            antlr4::ANTLRInputStream input(stream);
+	for (auto &InputFile : commandParse.getInputFiles()) {
+		LOG_VERBOSE("Parsing " << InputFile)
+		try {
+			std::ifstream stream(InputFile);
+			if (!stream.good()) {
+				throw std::invalid_argument("Invalid file " +
+							    InputFile);
+			}
+			antlr4::ANTLRInputStream input(stream);
 
-            nopLexer lexer(&input);
-            lexer.removeErrorListeners();
-            lexer.addErrorListener(&errorListener);
+			nopLexer lexer(&input);
+			lexer.removeErrorListeners();
+			lexer.addErrorListener(&errorListener);
 
-            antlr4::CommonTokenStream tokens(&lexer);
-            tokens.fill();
+			antlr4::CommonTokenStream tokens(&lexer);
+			tokens.fill();
 
-            nopParser parser(&tokens);
-            parser.removeErrorListeners();
-            parser.addErrorListener(&errorListener);
-            antlr4::tree::ParseTree *tree = parser.nop_file();
+			nopParser parser(&tokens);
+			parser.removeErrorListeners();
+			parser.addErrorListener(&errorListener);
+			antlr4::tree::ParseTree *tree = parser.nop_file();
 
-            LOG_DEBUG(tree->toStringTree(&parser));
-        } catch (std::invalid_argument &e) {
-            LOG_ERROR(e.what());
-            return 1;
-        }
-    }
-    return 0;
+			LOG_DEBUG(tree->toStringTree(&parser));
+		} catch (std::invalid_argument &e) {
+			LOG_ERROR(e.what());
+			return 1;
+		}
+	}
+	return 0;
 }
 
-int main(int argc, char **argv)
-{
-    CommandParse commandParse;
+int main(int argc, char **argv) {
+	CommandParse commandParse;
 
-    commandParse.parse(argc, argv);
-    IFDEBUG(
-        LOG_DEBUG("Output : " << commandParse.getOutputFile());
-        LOG_DEBUG("Inputs :");
-        for (auto &InputFile : commandParse.getInputFiles()) {
-            LOG_DEBUG("\t" << InputFile);
-        }
-    )
-    return parse_files(commandParse);
+	commandParse.parse(argc, argv);
+	IFDEBUG(LOG_DEBUG("Output : " << commandParse.getOutputFile());
+		LOG_DEBUG("Inputs :"); for (auto &InputFile
+					    : commandParse.getInputFiles()) {
+			LOG_DEBUG("\t" << InputFile);
+		})
+	return parse_files(commandParse);
 }


### PR DESCRIPTION
Some previous format did not conform to clang-format. This commit is simply the result of running clang-format on the src folder.